### PR TITLE
Record lucky loot

### DIFF
--- a/Extension/scripts/main.js
+++ b/Extension/scripts/main.js
@@ -1008,6 +1008,7 @@
     function getLoot(message, response, journal) {
         var loot_text = journal.publish_data.attachment.description.substring(journal.publish_data.attachment.description.indexOf("following loot:") + 15);
         var loot_array = loot_text.split(/,\s|\sand\s/g);
+        var render_array = journal.render_data.text.split(/<a\s/)
 
         message.loot = [];
         for (var i = 0, len = loot_array.length; i < len; i++) {
@@ -1055,6 +1056,10 @@
                 message.loot[i].amount = message.loot[i].amount * parseInt(loot_amount.replace(/,/, ''));
                 message.loot[i].name = 'Gold';
             }
+            var render_item = render_array.filter(function (render) {
+                return render.indexOf(loot_item[1]) !== -1
+            })[0]
+            message.loot[i].lucky = render_item && render_item.indexOf('class="lucky"') !== -1
         }
 
         return message;


### PR DESCRIPTION
It's the extension implementation of #42. To each loot item a new boolean field `lucky` is added.

On the server side I saw it is merging if multiple loots with the same name are received, so I want to ask if there is some logic that would be broken if merging is done on `name` and `lucky` flag being the same - i.e. potentially having two records in `hunt_loot` with same `hunt_id` and `loot_id`