### PR TITLE
Alias Twisted / Normal locations for Relic Hunter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ root = true
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{js,json}]
+[*.{js,json,php,sh}]
 indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,json}]
+indent_style = space
+indent_size = 4

--- a/DB/mh_db_auto_backup.sh
+++ b/DB/mh_db_auto_backup.sh
@@ -9,11 +9,11 @@ date > last_updated.txt
 echo "====== Backing up hunt helper ====="
 
 if [ -f hunthelper_weekly.sql.gz ]; then
-	rm hunthelper_weekly.sql.gz
+    rm hunthelper_weekly.sql.gz
 fi
 
 if [ -f hunthelper_weekly.txt.zip ]; then
-	rm hunthelper_weekly.txt.zip
+    rm hunthelper_weekly.txt.zip
 fi
 
 mysqldump -u $MH_USER -p$MH_PASS --host=127.0.0.1 --skip-lock-tables --events --routines mhhunthelper | gzip -9 > hunthelper_weekly.sql.gz
@@ -28,7 +28,7 @@ rm -rf /var/lib/mysql-files/*
 echo "===== Backing up map spotter ====="
 
 if [ -f mapspotter_weekly.sql.gz ]; then
-	rm mapspotter_weekly.sql.gz
+    rm mapspotter_weekly.sql.gz
 fi
 
 if [ -f mapspotter_weekly.txt.zip ]; then
@@ -48,11 +48,11 @@ rm -rf /var/lib/mysql-files/*
 echo "===== Backing up converter ====="
 
 if [ -f converter_weekly.sql.gz ]; then
-	rm converter_weekly.sql.gz
+    rm converter_weekly.sql.gz
 fi
 
 if [ -f converter_weekly.txt.zip ]; then
-	rm converter_weekly.txt.zip
+    rm converter_weekly.txt.zip
 fi
 
 mysqldump -u $MH_USER -p$MH_PASS --host=127.0.0.1 --skip-lock-tables --events --routines mhconverter --ignore-table=mhconverter.entries | gzip -9 > converter_weekly.sql.gz
@@ -68,7 +68,7 @@ rm -rf /var/lib/mysql-files/*
 echo "===== Backing up map helper ====="
 
 if [ -f maphelper_weekly.sql.gz ]; then
-	rm maphelper_weekly.sql.gz
+    rm maphelper_weekly.sql.gz
 fi
 
 if [ -f maphelper_weekly.txt.zip ]; then

--- a/DB/mh_db_auto_backup_nightly.sh
+++ b/DB/mh_db_auto_backup_nightly.sh
@@ -9,11 +9,11 @@ date > last_updated.txt
 echo "====== Backing up hunt helper ====="
 
 if [ -f hunthelper_nightly.sql.gz ]; then
-	rm hunthelper_nightly.sql.gz
+    rm hunthelper_nightly.sql.gz
 fi
 
 if [ -f hunthelper_nightly.txt.zip ]; then
-	rm hunthelper_nightly.txt.zip
+    rm hunthelper_nightly.txt.zip
 fi
 
 mysqldump -u $MH_USER -p$MH_PASS --host=127.0.0.1 --skip-lock-tables --events --routines mhhunthelper | gzip -9 > hunthelper_nightly.sql.gz

--- a/Main Page/index.php
+++ b/Main Page/index.php
@@ -57,7 +57,7 @@
                     <a href="https://mhhunthelper.agiletravels.com/mapper.php" style="display:block;text-decoration:none;color:#333;">Mapper</a>
                 </td></tr>
             <tr><td>
-					<a tabindex="0" class="glyphicon glyphicon-question-sign pull-right popover_styles" role="button" data-toggle="popover"
+                    <a tabindex="0" class="glyphicon glyphicon-question-sign pull-right popover_styles" role="button" data-toggle="popover"
                        data-content="Search convertibles like chests, to see what items are likely to be in them."></a>
                     <a href="https://mhhunthelper.agiletravels.com/converter.php" style="display:block;text-decoration:none;color:#333;">Converter</a>
                 </td></tr>

--- a/Main Page/scripts/main.js
+++ b/Main Page/scripts/main.js
@@ -1,9 +1,9 @@
 $(function () {
-	$('[data-toggle="popover"]').popover(
-		{
-			container: 'body',
-			placement: 'left',
-			trigger: 'click'
-		}
-	);
+    $('[data-toggle="popover"]').popover(
+        {
+            container: 'body',
+            placement: 'left',
+            trigger: 'click'
+        }
+    );
 });

--- a/Main Page/styles/main.css
+++ b/Main Page/styles/main.css
@@ -13,8 +13,8 @@
 .popover_styles:hover,
 .popover_styles:focus,
 .popover_styles:visited {
-	text-decoration: none;
-	color: gray;
-	position: relative;
-	top: 8px;
+    text-decoration: none;
+    color: gray;
+    position: relative;
+    top: 8px;
 }

--- a/Main Page/updates.php
+++ b/Main Page/updates.php
@@ -12,32 +12,32 @@
 <div class="container">
 <div class="col-sm-8 col-sm-offset-2">
     <h1>Updates<small> (newest first)</small></h1>
-	<ul>
-		<li>Added Groupsky's Sunken City zone recorder (18.4.13)</li>
-		<li>Updated options page view (18.4.13)</li>
-		<li>Fixed link to Tsitu's Loader (18.4.13)</li>
-		<li>Added custom sound and volume (18.4.9)</li>
-		<li>Added web alert (18.4.9)</li>
-		<li>Updated options styling (18.4.9)</li>
-		<li>Added Tsitu's Bookmarklet Loader (18.4.8)</li>
-		<li>Fixed icon countdown timer on classic layout (18.3.31)</li>
-		<li>Fixed icon countdown timer king's reward detection (18.3.31)</li>
-		<li>Added per catch rate to looter tool (18.3.31)</li>
-		<li>Added icon countdown timer (18.3.21)</li>
-		<li>Added horn ready sound (18.3.21)</li>
-		<li>Added desktop notification (18.3.21)</li>
-		<li>Fixed new mice not being recorded through new maps</li>
-		<li>Updated Tsitus bookmarklets and their execution mechanism (1.12.29)</li>
-		<li>Added version to popup (1.12.29)</li>
-		<li>Fixed messages (1.12.29)</li>
-		<li>Updated Tsitus CRE and Best Setup (1.12.28)</li>
-		<li>Small Crown collector update (1.12.27)</li>
-	    <li>Added Crown collector with Tehhowch's help (1.12.26)</li>
-	    <li>Updated Tsitu's scripts to latest version (1.12.26)</li>
-		<li>Added RH time check to make sure it's after reset (1.12.25)</li>
-		<li>Added a type of UUID for each request (1.12.25)</li>
-		<li>M400 Fix (brought to you by @groupsky) (1.12.24)</li>
-		<li>2018 Birthday stages and other info (brought to you by @groupsky) (1.12.24)</li>
+    <ul>
+        <li>Added Groupsky's Sunken City zone recorder (18.4.13)</li>
+        <li>Updated options page view (18.4.13)</li>
+        <li>Fixed link to Tsitu's Loader (18.4.13)</li>
+        <li>Added custom sound and volume (18.4.9)</li>
+        <li>Added web alert (18.4.9)</li>
+        <li>Updated options styling (18.4.9)</li>
+        <li>Added Tsitu's Bookmarklet Loader (18.4.8)</li>
+        <li>Fixed icon countdown timer on classic layout (18.3.31)</li>
+        <li>Fixed icon countdown timer king's reward detection (18.3.31)</li>
+        <li>Added per catch rate to looter tool (18.3.31)</li>
+        <li>Added icon countdown timer (18.3.21)</li>
+        <li>Added horn ready sound (18.3.21)</li>
+        <li>Added desktop notification (18.3.21)</li>
+        <li>Fixed new mice not being recorded through new maps</li>
+        <li>Updated Tsitus bookmarklets and their execution mechanism (1.12.29)</li>
+        <li>Added version to popup (1.12.29)</li>
+        <li>Fixed messages (1.12.29)</li>
+        <li>Updated Tsitus CRE and Best Setup (1.12.28)</li>
+        <li>Small Crown collector update (1.12.27)</li>
+        <li>Added Crown collector with Tehhowch's help (1.12.26)</li>
+        <li>Updated Tsitu's scripts to latest version (1.12.26)</li>
+        <li>Added RH time check to make sure it's after reset (1.12.25)</li>
+        <li>Added a type of UUID for each request (1.12.25)</li>
+        <li>M400 Fix (brought to you by @groupsky) (1.12.24)</li>
+        <li>2018 Birthday stages and other info (brought to you by @groupsky) (1.12.24)</li>
         <li>Renamed data backups for clarity (1.12.23)</li>
         <li>Added backend framework to record hunt details (1.12.23)</li>
         <li>Added latest Tsitu's scripts (1.12.23)</li>
@@ -72,94 +72,94 @@
         <li>Increased loot drop rate precision to 3 digits</li>
         <li>Activated Ryonn's Tavern auto-populated link (1.12.13)</li>
         <li>Switched to new messaging for FF flash messages (1.12.13)</li>
-		<li>Added user settings for displaying messages (1.12.12)</li>
-		<li>Added some more links to extension (1.12.12)</li>
-		<li>Fixed more FW transition mice (1.12.11)</li>
-		<li>Added flash message (1.12.11)</li>
-		<li>Redesigned extension popup (1.12.11)</li>
-		<li>Added extension popup error message (1.12.11)</li>
-		<li>Fixed WWR stages logic (1.12.01)</li>
-		<li>Separated stages from hunts in a multi to one relationship</li>
-		<li>Added client side RH tracking (1.12.00)</li>
-		<li>Added client side WWR stages logic (1.12.00)</li>
-		<li>Fixed transition mice rules (1.12.00)</li>
-		<li>Added Mapper Tool</li>
-		<li>Added Spotter integration with Discord</li>
-		<li>Added new Toxic Spill with stages (1.11.11)</li>
-		<li>Fixed few loot spellings (1.11.11)</li>
-		<li>Added Spotter tool</li>
-		<li>Added map mice tracker (1.11.9)</li>
-		<li>Added more transition mice rules (1.11.9)</li>
-		<li>Updated icon (1.11.9)</li>
-		<li>Optimized db queries for attractions and drops even more</li>
-		<li>Changed sort by total hunts, displayed them on mobile, and removed attracted column to simplify</li>
-		<li>Added new version db format for better storage and queries (1.11.8)</li>
-		<li>Fixed few loot spelling exceptions (1.11.8)</li>
-		<li>Added loot search page</li>
-		<li>Added loot tracking (1.11.7)</li>
-		<li>Opera extension approved and published (1.11.6)</li>
-		<li>Added Bristle Woods Rift stages (1.11.5)</li>
-		<li>Added asterisks to map-helper for mice that require or avoid charms</li>
-		<li>Firefox native add-on approved and posted</li>
-		<li>Submitted to Opera and Firefox add-on stores</li>
-		<li>Added checks for cheese, trap, and base (1.11.4)</li>
-		<li>Added more precise mist checks for Burroughs Rift (1.11.4)</li>
-		<li>Squished a few Zokor and transitional mice bugs (1.11.3)</li>
-		<li>Fixed LG/Sand/City locations (1.11.2)</li>
-		<li>Updated auto-population to be more reliable and simpler (1.11.1)</li>
-		<li>Added a link to user hunt history (1.11.1)</li>
-		<li>Added reminder to refresh mh page with new version of extension is installed (1.11.0)</li>
-		<li>Added auto-navigate to mh tab on auto-pop link click (1.11.0)</li>
-		<li>Added auto-population for two map solvers (1.11.0)</li>
-		<li>Added FB support (1.10.0)</li>
-		<li>Added http support (1.9.3)</li>
-		<li>Added FG stages (1.9.2)</li>
-		<li>Fixed Zokor stages (1.9.2)</li>
-		<li>Updated databases to integrate better with map helper</li>
-		<li>Changed names of stages for: Iceberg, Labby, Zokor, Train, and LG (1.9.1)</li>
-		<li>Added exception for Icewing (1.9.1)</li>
-		<li>Removed FC stages (it's cheese based) (1.9)</li>
-		<li>Fixed Warmonger stage to be wave 4 (there is not wave 5, silly me) (1.9)</li>
-		<li>Moved to main host server (should be a bit more stable now) (1.9)</li>
-		<li>Removed riptide hunts for now (no way to tell stage) (1.9)</li>
-		<li>Started integration with MH Map Helper (1.9)</li>
-		<li>Created per user hunts display page with CSV and XLSX export</li>
-		<li>Fixed data missing stages</li>
-		<li>Fixed charms recording</li>
-		<li>Added cheese to attraction rate page</li>
-		<li>Fixed some transition mice like warmonger, hotm, and realm ripper. (1.8)</li>
-		<li>Added icon with popup and links (1.8)</li>
-		<li>Added stages to SG, Frox, and Train (1.8)</li>
-		<li>Added stages for: Toxic Spill, Twisted Garden, Cursed City, Furoma Rift and Burroughs Rift (1.7)</li>
-		<li>Fixed auto-update check (1.6)</li>
-		<li>Moved intake server url (1.6)</li>
-		<li>Added extension version records to see if everyone is getting auto-updated (1.6)</li>
-		<li>Optimized website for speed loading (except caching)</li>
-		<li>Made autocomplete local and faster</li>
-		<li>Added Datatables: sort, hidden column, styling</li>
-		<li>Converted mouse select box into a search box with autocomplete (800+ mice is not a good dropdown)</li>
-		<li>Added ajax to attraction page, so to only load table, not whole page</li>
-		<li>Added autoupdate check (v1.5)</li>
-		<li>Removed unnecessary permissions (v1.5)</li>
-		<li>Added Sunken City, Fungal Cavern, Zokor stages (v1.5)</li>
-		<li>Added LG, Sand Dunes, Lost City, Balack's Cove, Iceberg stages (v1.4)</li>
-		<li>Added Fiery Warpath stages (v1.3)</li>
-		<li>Added Labyrinth hallway stages (v1.2)</li>
-		<li>Refactored intake to remove repetetive code</li>
-		<li>Added loader animation</li>
-		<li>Fixed some regex on mice names, so they don't show anything but mice names</li>
-		<li>Made the extension only capture latest hunt by player, as trap setup is not known for other hunts</li>
-		<li>Put the extension in the Chrome Store for easy availability and auto updates</li>
-		<li>Made everything open source by putting it on GitHub</li>
-		<li>Setup git repository to keep track of changes</li>
-		<li>Added meaningful server response messages</li>
-		<li>Added validation on server and client side to minimize server load</li>
-		<li>Successfully installed and tested Chrome extension in Opera and Firefox</li>
-		<li>Made the site responsive for mobile phones</li>
-		<li>Created quick and dirty attraction webpage to see a bit of data</li>
-		<li>Created simple database and intake api</li>
-		<li>Created quick and dirty Chrome extension (for non-facebook site only) (v1.0)</li>
-	</ul>
+        <li>Added user settings for displaying messages (1.12.12)</li>
+        <li>Added some more links to extension (1.12.12)</li>
+        <li>Fixed more FW transition mice (1.12.11)</li>
+        <li>Added flash message (1.12.11)</li>
+        <li>Redesigned extension popup (1.12.11)</li>
+        <li>Added extension popup error message (1.12.11)</li>
+        <li>Fixed WWR stages logic (1.12.01)</li>
+        <li>Separated stages from hunts in a multi to one relationship</li>
+        <li>Added client side RH tracking (1.12.00)</li>
+        <li>Added client side WWR stages logic (1.12.00)</li>
+        <li>Fixed transition mice rules (1.12.00)</li>
+        <li>Added Mapper Tool</li>
+        <li>Added Spotter integration with Discord</li>
+        <li>Added new Toxic Spill with stages (1.11.11)</li>
+        <li>Fixed few loot spellings (1.11.11)</li>
+        <li>Added Spotter tool</li>
+        <li>Added map mice tracker (1.11.9)</li>
+        <li>Added more transition mice rules (1.11.9)</li>
+        <li>Updated icon (1.11.9)</li>
+        <li>Optimized db queries for attractions and drops even more</li>
+        <li>Changed sort by total hunts, displayed them on mobile, and removed attracted column to simplify</li>
+        <li>Added new version db format for better storage and queries (1.11.8)</li>
+        <li>Fixed few loot spelling exceptions (1.11.8)</li>
+        <li>Added loot search page</li>
+        <li>Added loot tracking (1.11.7)</li>
+        <li>Opera extension approved and published (1.11.6)</li>
+        <li>Added Bristle Woods Rift stages (1.11.5)</li>
+        <li>Added asterisks to map-helper for mice that require or avoid charms</li>
+        <li>Firefox native add-on approved and posted</li>
+        <li>Submitted to Opera and Firefox add-on stores</li>
+        <li>Added checks for cheese, trap, and base (1.11.4)</li>
+        <li>Added more precise mist checks for Burroughs Rift (1.11.4)</li>
+        <li>Squished a few Zokor and transitional mice bugs (1.11.3)</li>
+        <li>Fixed LG/Sand/City locations (1.11.2)</li>
+        <li>Updated auto-population to be more reliable and simpler (1.11.1)</li>
+        <li>Added a link to user hunt history (1.11.1)</li>
+        <li>Added reminder to refresh mh page with new version of extension is installed (1.11.0)</li>
+        <li>Added auto-navigate to mh tab on auto-pop link click (1.11.0)</li>
+        <li>Added auto-population for two map solvers (1.11.0)</li>
+        <li>Added FB support (1.10.0)</li>
+        <li>Added http support (1.9.3)</li>
+        <li>Added FG stages (1.9.2)</li>
+        <li>Fixed Zokor stages (1.9.2)</li>
+        <li>Updated databases to integrate better with map helper</li>
+        <li>Changed names of stages for: Iceberg, Labby, Zokor, Train, and LG (1.9.1)</li>
+        <li>Added exception for Icewing (1.9.1)</li>
+        <li>Removed FC stages (it's cheese based) (1.9)</li>
+        <li>Fixed Warmonger stage to be wave 4 (there is not wave 5, silly me) (1.9)</li>
+        <li>Moved to main host server (should be a bit more stable now) (1.9)</li>
+        <li>Removed riptide hunts for now (no way to tell stage) (1.9)</li>
+        <li>Started integration with MH Map Helper (1.9)</li>
+        <li>Created per user hunts display page with CSV and XLSX export</li>
+        <li>Fixed data missing stages</li>
+        <li>Fixed charms recording</li>
+        <li>Added cheese to attraction rate page</li>
+        <li>Fixed some transition mice like warmonger, hotm, and realm ripper. (1.8)</li>
+        <li>Added icon with popup and links (1.8)</li>
+        <li>Added stages to SG, Frox, and Train (1.8)</li>
+        <li>Added stages for: Toxic Spill, Twisted Garden, Cursed City, Furoma Rift and Burroughs Rift (1.7)</li>
+        <li>Fixed auto-update check (1.6)</li>
+        <li>Moved intake server url (1.6)</li>
+        <li>Added extension version records to see if everyone is getting auto-updated (1.6)</li>
+        <li>Optimized website for speed loading (except caching)</li>
+        <li>Made autocomplete local and faster</li>
+        <li>Added Datatables: sort, hidden column, styling</li>
+        <li>Converted mouse select box into a search box with autocomplete (800+ mice is not a good dropdown)</li>
+        <li>Added ajax to attraction page, so to only load table, not whole page</li>
+        <li>Added autoupdate check (v1.5)</li>
+        <li>Removed unnecessary permissions (v1.5)</li>
+        <li>Added Sunken City, Fungal Cavern, Zokor stages (v1.5)</li>
+        <li>Added LG, Sand Dunes, Lost City, Balack's Cove, Iceberg stages (v1.4)</li>
+        <li>Added Fiery Warpath stages (v1.3)</li>
+        <li>Added Labyrinth hallway stages (v1.2)</li>
+        <li>Refactored intake to remove repetetive code</li>
+        <li>Added loader animation</li>
+        <li>Fixed some regex on mice names, so they don't show anything but mice names</li>
+        <li>Made the extension only capture latest hunt by player, as trap setup is not known for other hunts</li>
+        <li>Put the extension in the Chrome Store for easy availability and auto updates</li>
+        <li>Made everything open source by putting it on GitHub</li>
+        <li>Setup git repository to keep track of changes</li>
+        <li>Added meaningful server response messages</li>
+        <li>Added validation on server and client side to minimize server load</li>
+        <li>Successfully installed and tested Chrome extension in Opera and Firefox</li>
+        <li>Made the site responsive for mobile phones</li>
+        <li>Created quick and dirty attraction webpage to see a bit of data</li>
+        <li>Created simple database and intake api</li>
+        <li>Created quick and dirty Chrome extension (for non-facebook site only) (v1.0)</li>
+    </ul>
 </div>
 <?php include_once("ga.php") ?>
 </div>

--- a/Server/converter.php
+++ b/Server/converter.php
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-	<title>Jack's MH Converter</title>
+    <title>Jack's MH Converter</title>
     <?php require "common_head.php"; ?>
     <script defer src="/scripts/converter.js"></script>
 </head>

--- a/Server/intake.php
+++ b/Server/intake.php
@@ -90,8 +90,8 @@ if ($_POST['extension_version'] >= 11217) {
     $fields .= ', attraction_bonus, total_power, total_luck';
     $values .= ', :attraction_bonus, :total_power, :total_luck';
     $bindings['attraction_bonus'] = $_POST['attraction_bonus'];
-    $bindings['total_power'] 	  = $_POST['total_power'];
-    $bindings['total_luck'] 	  = $_POST['total_luck'];
+    $bindings['total_power']      = $_POST['total_power'];
+    $bindings['total_luck']       = $_POST['total_luck'];
 }
 
 // Optionals
@@ -168,7 +168,7 @@ if (!empty($_POST['stage']) && !empty($hunt_id)) {
 // Loot
 if (!empty($_POST['loot']) && $hunt_id > 0) {
     $loot_array = [];
-	$gold_array = [15, 47, 106, 138, 191, 194, 210, 226, 227, 260, 261, 262, 264, 265];
+    $gold_array = [15, 47, 106, 138, 191, 194, 210, 226, 227, 260, 261, 262, 264, 265];
     foreach ($_POST['loot'] as $loot_item) {
         $loot_item['amount'] = str_replace(",", "", $loot_item['amount']);
         if (!is_numeric($loot_item['amount']) || $loot_item['amount'] < 1) {
@@ -183,10 +183,10 @@ if (!empty($_POST['loot']) && $hunt_id > 0) {
         $query = $pdo->prepare("SELECT id FROM loot WHERE name LIKE ?");
         $query->execute(array($loot_item['name']));
         $loot_id = $query->fetchColumn();
-		
-		if (in_array($loot_id, $gold_array)) { // Blocking gold, there could be multiples of it, and not accurate
-			continue;
-		}
+        
+        if (in_array($loot_id, $gold_array)) { // Blocking gold, there could be multiples of it, and not accurate
+            continue;
+        }
 
         if (!$loot_id) {
             $query = $pdo->prepare('INSERT INTO loot (name) VALUES (?)');
@@ -234,7 +234,7 @@ if (!empty($_POST['hunt_details']) && !empty($hunt_id)) {
 
 // Giveaway
 if ($_POST['entry_timestamp'] >= $giveaway_start_time && $_POST['entry_timestamp'] <= $giveaway_end_time) {
-	recordGiveawayHunt($_POST['user_id'], $_POST['entry_timestamp']);
+    recordGiveawayHunt($_POST['user_id'], $_POST['entry_timestamp']);
 }
 
 sendResponse('success', "Thanks for the hunt info!");
@@ -248,11 +248,11 @@ function sendResponse($status, $message) {
 }
 
 function recordGiveawayHunt($user = '', $timestamp = '') {
-	global $giveaway_url, $giveaway_key;
-	$url = $giveaway_url;
-	$url .= '?user=' . $user . '&ts=' . $timestamp;
-	$url .= '&mykey=' . $giveaway_key;
-	$nothing = file_get_contents($url);
+    global $giveaway_url, $giveaway_key;
+    $url = $giveaway_url;
+    $url .= '?user=' . $user . '&ts=' . $timestamp;
+    $url .= '&mykey=' . $giveaway_key;
+    $nothing = file_get_contents($url);
 }
 
 function formatVersion($version) {
@@ -268,9 +268,9 @@ function formatVersion($version) {
 }
 
 function recordRelicHunter() {
-	if (empty($_POST['entry_timestamp']) || !is_numeric($_POST['entry_timestamp'])) {
-		return;
-	}
+    if (empty($_POST['entry_timestamp']) || !is_numeric($_POST['entry_timestamp'])) {
+        return;
+    }
 
     $file_name = 'tracker.json';
     $location = filter_var($_POST['rh_environment'], FILTER_SANITIZE_STRING);
@@ -280,10 +280,10 @@ function recordRelicHunter() {
     if (!empty($data)) {
         $data = json_decode($data);
         if (empty($data->rh) || $data->rh->last_seen > $_POST['entry_timestamp'] ) {
-			return;
-		}
-		$data->rh->location = $location;
-		$data->rh->last_seen = $_POST['entry_timestamp'];
+            return;
+        }
+        $data->rh->location = $location;
+        $data->rh->last_seen = $_POST['entry_timestamp'];
     } else {
         $data = [
             "rh" => [

--- a/Server/intake.php
+++ b/Server/intake.php
@@ -267,13 +267,37 @@ function formatVersion($version) {
     return $version;
 }
 
+function getAliasLocationName($input) {
+    switch ($input) {
+        case 'Living Garden':
+        case 'Twisted Garden':
+            $input = 'Living/Twisted Garden';
+            break;
+
+        case 'Sand Dunes':
+        case 'Sand Crypts':
+            $input = 'Sand Dunes/Crypts';
+            break;
+
+        case 'Lost City':
+        case 'Cursed City':
+            $input = 'Lost/Cursed City';
+            break;
+
+        default:
+            // No-op
+            break;
+    }
+    return $input
+}
+
 function recordRelicHunter() {
     if (empty($_POST['entry_timestamp']) || !is_numeric($_POST['entry_timestamp'])) {
         return;
     }
 
     $file_name = 'tracker.json';
-    $location = filter_var($_POST['rh_environment'], FILTER_SANITIZE_STRING);
+    $location = getAliasLocationName(filter_var($_POST['rh_environment'], FILTER_SANITIZE_STRING));
 
     $data = file_get_contents($file_name);
 

--- a/Server/loot.php
+++ b/Server/loot.php
@@ -1,9 +1,9 @@
 <html lang="en">
 <head>
-	<title>Jack's MH Looter</title>
+    <title>Jack's MH Looter</title>
     <?php require "common_head.php"; ?>
     <script defer src="/scripts/loot.js"></script>
-	<link rel="stylesheet" type="text/css" href="styles/loot.css">
+    <link rel="stylesheet" type="text/css" href="styles/loot.css">
 </head>
 <body style="text-align: center;" class="text-center">
     <!-- Jumbotron -->
@@ -12,43 +12,43 @@
         <a href="https://agiletravels.com" class="clickable"><span class="glyphicon glyphicon-chevron-left"></span> Jack's MH Tools</a>
     </div>
     <div class="container">
-		<form id="search_options">
+        <form id="search_options">
         <input id="prev_item" type="hidden" value="<?php (!empty($_GET['item']) ? print $_GET['item'] : '' ) ?>">
         <input id="prev_timefilter" type="hidden" value="<?php (!empty($_GET['timefilter']) ? print $_GET['timefilter'] : 'all' ) ?>">
         <div class="input-group col-sm-6 col-sm-offset-3">
             <div class="input-group" style="width:100%">
-				<div class="input-group-addon"><strong>Loot:</strong></div>
-				<input name="item" id="item" class="form-control input-lg" type="text" placeholder="Start typing loot name and select." autofocus>
-			</div>
+                <div class="input-group-addon"><strong>Loot:</strong></div>
+                <input name="item" id="item" class="form-control input-lg" type="text" placeholder="Start typing loot name and select." autofocus>
+            </div>
 
-			<div class="input-group" style="width:100%">
-				<div class="input-group-addon"><strong>Time:</strong></div>
-				<select class="form-control input-lg" id="timefilter" name="timefilter">
-					<option value="all" selected>All Time</option>
-					<option value="last3days">Last 3 days</option>
-					<option value="seh2018">Spring Egg Hunt 2018</option>
-					<option value="stpatty2018">St Patty 2018</option>
-					<option value="bd2018">Birthday event 2018</option>
-				</select>
-			</div>
+            <div class="input-group" style="width:100%">
+                <div class="input-group-addon"><strong>Time:</strong></div>
+                <select class="form-control input-lg" id="timefilter" name="timefilter">
+                    <option value="all" selected>All Time</option>
+                    <option value="last3days">Last 3 days</option>
+                    <option value="seh2018">Spring Egg Hunt 2018</option>
+                    <option value="stpatty2018">St Patty 2018</option>
+                    <option value="bd2018">Birthday event 2018</option>
+                </select>
+            </div>
 
             <div id="erase_item" class="input-group-addon fakebutton"><span class="glyphicon glyphicon-remove"></span></div>
         </div>
-		<div class="input-group col-sm-6 col-sm-offset-3">
-			<div class="input-group" style="width:100%">
-				<div class="input-group-addon"><strong>Options:</strong></div>
-				<div class="form-control">
-					<label>
-					<div class="switch">
-						<input type="checkbox" id="rate_per_catch" value="1">
-						<span class="slider round"></span>
-					</div>
-					<span class="switch_label">Show catches and rate per catch</span>
-				  </label>
-				</div>
-			</div>
-		</div>
-		</form>
+        <div class="input-group col-sm-6 col-sm-offset-3">
+            <div class="input-group" style="width:100%">
+                <div class="input-group-addon"><strong>Options:</strong></div>
+                <div class="form-control">
+                    <label>
+                    <div class="switch">
+                        <input type="checkbox" id="rate_per_catch" value="1">
+                        <span class="slider round"></span>
+                    </div>
+                    <span class="switch_label">Show catches and rate per catch</span>
+                  </label>
+                </div>
+            </div>
+        </div>
+        </form>
         <br/>
 
         <div id="results" class="table-responsive"></div>

--- a/Server/map_intake.php
+++ b/Server/map_intake.php
@@ -109,9 +109,9 @@ if ($mice_supplied_count != $mice_inserted_count) {
 sendResponse('success', "Thanks for the map info!");
 
 function sendResponse($status, $message) {
-	$response = json_encode([
-		'status' => $status,
-		'message' => $message
-	]);
-	die($response);
+    $response = json_encode([
+        'status' => $status,
+        'message' => $message
+    ]);
+    die($response);
 }

--- a/Server/mapper.php
+++ b/Server/mapper.php
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-	<title>Jack's MH Mapper</title>
+    <title>Jack's MH Mapper</title>
     <?php require "common_head.php"; ?>
     <script defer src="/scripts/mapper.js"></script>
 </head>

--- a/Server/missing_mice.php
+++ b/Server/missing_mice.php
@@ -26,10 +26,10 @@ $query->execute();
         <tr><th colspan="2" class="text-center">Mice missing from tools (except map helper)</th></tr></thead>
     <tbody>
 <?php
-	$mouse_count = 1;
+    $mouse_count = 1;
     while ( $row = $query->fetch(PDO::FETCH_ASSOC)) {
         print "<tr><td>$mouse_count</td><td>$row[mouse]</td></tr>";
-		$mouse_count++;
+        $mouse_count++;
     }
 ?>
 </tbody></table>

--- a/Server/scripts/loot.js
+++ b/Server/scripts/loot.js
@@ -5,7 +5,7 @@ $( function() {
         $('#timefilter').val('all');
         $("#prev_item").val('');
         $("#prev_timefilter").val('');
-		$("#rate_per_catch").val('');
+        $("#rate_per_catch").val('');
         window.history.replaceState({}, "MH Hunt Helper", "loot.php");
     });
 
@@ -60,7 +60,7 @@ $( function() {
         $('#timefilter').change(function() {
             searchItems($('#prev_item').val(), renderResultsTable, $('#timefilter').val());
         });
-		$('#rate_per_catch').change(function() {
+        $('#rate_per_catch').change(function() {
             searchItems($('#prev_item').val(), renderResultsTable, $('#timefilter').val());
         });
     }
@@ -84,11 +84,11 @@ $( function() {
     }
 
     function renderResultsTable(data) {
-		var show_rate_per_catch = $('#rate_per_catch').is(':checked');
-		var rate_per_catch_title = '';
-		if (show_rate_per_catch) {
-			rate_per_catch_title = '<th>Rate per catch</th><th>Catches</th>';
-		}
+        var show_rate_per_catch = $('#rate_per_catch').is(':checked');
+        var rate_per_catch_title = '';
+        if (show_rate_per_catch) {
+            rate_per_catch_title = '<th>Rate per catch</th><th>Catches</th>';
+        }
         var final_html = '<table id="results_table" class="table table-striped table-hover" style="width:100%"><thead><tr><th>Location</th><th>Stage</th><th>Cheese</th><th>Rate per hunt</th><th>Hunts</th>' + rate_per_catch_title + '</tr></thead><tbody>';
 
         var all_stages = '';
@@ -101,10 +101,10 @@ $( function() {
                 + row.cheese + '</td><td>'
                 + parseFloat(((row.rate)/1000).toFixed(3)) + '</td><td>'
                 + row.total_hunts + '</td>';
-			if (show_rate_per_catch) {
-				final_html += '<td>' + parseFloat(((row.rate_per_catch)/1000).toFixed(3)) + '</td><td>' + row.total_catches + '</td>';
-			}
-			final_html += '</tr>';
+            if (show_rate_per_catch) {
+                final_html += '<td>' + parseFloat(((row.rate_per_catch)/1000).toFixed(3)) + '</td><td>' + row.total_catches + '</td>';
+            }
+            final_html += '</tr>';
         });
         final_html += '</tbody></table>';
         $("#results").html(final_html);

--- a/Server/searchByItem.php
+++ b/Server/searchByItem.php
@@ -136,7 +136,7 @@ function getLootQuery(&$query_all, &$query_one) {
         }
     }
 
-	# blocking gold
+    # blocking gold
     $query_all = 'SELECT id, name FROM loot where id NOT IN (15, 47, 106, 138, 191, 194, 210, 226, 227, 260, 261, 262, 264, 265)';
     $query_one = '
         SELECT l.name AS location, s.name AS stage, h.total_hunts, h.rate, c.name AS cheese, h.rate_per_catch, h.total_catches

--- a/Server/searchByUser.php
+++ b/Server/searchByUser.php
@@ -32,9 +32,9 @@ if (empty($_GET['user']) || !is_numeric($_GET['user'])) {
     ?><script>$("#loader").css( "display", "none" );</script><?php
     return;
 } else {
-	$not_direct_access_id = true;
+    $not_direct_access_id = true;
     $encrypted_user_id = $_GET['user'];
-	require "id_modifier.php";
+    require "id_modifier.php";
 }
 
 require "config.php";

--- a/Server/stats.php
+++ b/Server/stats.php
@@ -12,27 +12,27 @@ $pdo3 = new PDO("mysql:host=$convertible_servername;dbname=$convertible_dbname;c
 $pdo3->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
 
 $stat_variables = [
-	'hunts' => $pdo,
-	'users' => $pdo,
-	'mice' => $pdo,
-	'locations' => $pdo,
-	'traps' => $pdo,
-	'cheese' => $pdo,
-	'bases' => $pdo,
-	'charms' => $pdo,
-	'loot' => $pdo,
-	'stages' => $pdo,
-	'maps' => $pdo2,
-	'map_records' => $pdo2,
-	'convertibles' => $pdo3,
-	'entries' => $pdo3
-	];
+    'hunts' => $pdo,
+    'users' => $pdo,
+    'mice' => $pdo,
+    'locations' => $pdo,
+    'traps' => $pdo,
+    'cheese' => $pdo,
+    'bases' => $pdo,
+    'charms' => $pdo,
+    'loot' => $pdo,
+    'stages' => $pdo,
+    'maps' => $pdo2,
+    'map_records' => $pdo2,
+    'convertibles' => $pdo3,
+    'entries' => $pdo3
+    ];
 
 $stat_variable_values = [];
 foreach ($stat_variables as $name => $dbh) {
-	$query = $dbh->prepare('SELECT COUNT(*) FROM ' . $name);
-	$query->execute();
-	$stat_variable_values[$name] = $query->fetchColumn();
+    $query = $dbh->prepare('SELECT COUNT(*) FROM ' . $name);
+    $query->execute();
+    $stat_variable_values[$name] = $query->fetchColumn();
 }
 
 ?>
@@ -40,19 +40,19 @@ foreach ($stat_variables as $name => $dbh) {
     <thead>
         <tr><th colspan="2" class="text-center">Jack's Tools so far</th></tr></thead>
     <tbody>
-        <tr><td>Contributors:</td><td>      		<?php echo $stat_variable_values['users']; ?> - Thank you! :)</td></tr>
-        <tr><td>Hunt submissions</td><td>   		<?php echo $stat_variable_values['hunts']; ?></td></tr>
-        <tr><td>Map submissions</td><td>    		<?php echo $stat_variable_values['map_records']; ?></td></tr>
+        <tr><td>Contributors:</td><td>              <?php echo $stat_variable_values['users']; ?> - Thank you! :)</td></tr>
+        <tr><td>Hunt submissions</td><td>           <?php echo $stat_variable_values['hunts']; ?></td></tr>
+        <tr><td>Map submissions</td><td>            <?php echo $stat_variable_values['map_records']; ?></td></tr>
         <tr><td>Convertible submissions</td><td>    <?php echo $stat_variable_values['entries']; ?></td></tr>
-        <tr><td>Traps</td><td>              		<?php echo $stat_variable_values['traps']; ?></td></tr>
-        <tr><td>Bases</td><td>              		<?php echo $stat_variable_values['bases']; ?></td></tr>
-        <tr><td>Charms</td><td>             		<?php echo $stat_variable_values['charms']; ?></td></tr>
-        <tr><td>Cheese</td><td>            			<?php echo $stat_variable_values['cheese']; ?></td></tr>
-        <tr><td>Mice</td><td>               		<?php echo $stat_variable_values['mice']; ?></td></tr>
-        <tr><td>Locations</td><td>          		<?php echo $stat_variable_values['locations']; ?></td></tr>
-        <tr><td>Stages</td><td>             		<?php echo $stat_variable_values['stages']; ?></td></tr>
-        <tr><td>Loot</td><td>               		<?php echo $stat_variable_values['loot']; ?></td></tr>
-        <tr><td>Maps</td><td>               		<?php echo $stat_variable_values['maps']; ?></td></tr>
+        <tr><td>Traps</td><td>                      <?php echo $stat_variable_values['traps']; ?></td></tr>
+        <tr><td>Bases</td><td>                      <?php echo $stat_variable_values['bases']; ?></td></tr>
+        <tr><td>Charms</td><td>                     <?php echo $stat_variable_values['charms']; ?></td></tr>
+        <tr><td>Cheese</td><td>                     <?php echo $stat_variable_values['cheese']; ?></td></tr>
+        <tr><td>Mice</td><td>                       <?php echo $stat_variable_values['mice']; ?></td></tr>
+        <tr><td>Locations</td><td>                  <?php echo $stat_variable_values['locations']; ?></td></tr>
+        <tr><td>Stages</td><td>                     <?php echo $stat_variable_values['stages']; ?></td></tr>
+        <tr><td>Loot</td><td>                       <?php echo $stat_variable_values['loot']; ?></td></tr>
+        <tr><td>Maps</td><td>                       <?php echo $stat_variable_values['maps']; ?></td></tr>
         <tr><td>Convertibles</td><td>               <?php echo $stat_variable_values['convertibles']; ?></td></tr>
     </tbody>
 </table><br/>

--- a/Server/styles/loot.css
+++ b/Server/styles/loot.css
@@ -7,7 +7,7 @@
 }
 
 .switch_label {
-	vertical-align: top;
+    vertical-align: top;
 }
 
 /* Hide default HTML checkbox */


### PR DESCRIPTION
 - Add an .editorconfig file to suggest to certain IDEs that spaces > tabs for this repo
 - Replaces current tabs with 4 spaces, where some tabs have snuck in
 - Adds a function to alias locations for the Relic Hunter, to prevent the appearance of RH moving locations when really it was just seen most recently by someone in the other side.
   - Extendable to other cases, should they arise.